### PR TITLE
Fix error for undefined behavior

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
 	char *kv, *js_string, *progname, *pretty = NULL, buf[BUFSIZ];
 	JsonNode *json;
 
-	progname = (progname = strrchr(*argv, '/')) ? ++progname : *argv;
+	progname = (progname = strrchr(*argv, '/')) ? progname + 1 : *argv;
 
 	while ((c = getopt(argc, argv, "ap")) != EOF) {
 		switch (c) {


### PR DESCRIPTION
I got the following error when running `make`:

```
cc -Wall -Werror   -c -o json.o json.c
cc -Wall -Werror -o jo jo.c json.o
jo.c: In function ‘main’:
jo.c:127:11: error: operation on ‘progname’ may be undefined [-Werror=sequence-point]
  progname = (progname = strrchr(*argv, '/')) ? ++progname : *argv;
           ^
cc1: all warnings being treated as errors
Makefile:7: recipe for target 'jo' failed
make: *** [jo] Error 1
```