### PR TITLE
Use LDFLAGS when linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS += -Wall -Werror
 all: jo jo.1 jo.md
 
 jo: jo.c json.o
-	$(CC) $(CFLAGS) -o jo jo.c json.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o jo jo.c json.o
 
 json.o: json.c json.h
 


### PR DESCRIPTION
Some distributions may wish to override linker options globally. They usually put a sensible LDFLAGS environment parameter and it is expected this parameter to be picked by the build system. On Debian, for example, this is `-Wl,-z,relro`.