### PR TITLE
Add cast to suppress warning when compiling with GCC 4.8.4

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -86,7 +86,7 @@ JsonNode *boolnode(char *str)
 		return json_mknull();
 	}
 
-	if (tolower(*str) == 't') {
+	if (tolower((unsigned char) *str) == 't') {
 		return json_mkbool(1);
 	}
 


### PR DESCRIPTION
When compiling on NetBSD, with gcc version 4.8.4, I'm getting the following warning :

```
make
  CC       jo.o
jo.c: In function 'boolnode':
jo.c:89:2: warning: array subscript has type 'char' [-Wchar-subscripts]
  if (tolower(*str) == 't') {
  ^
  CCLD     jo
```

This diff adds a cast to fix the issue. I know you removed '-Werror' for now but better be proactive so it doesn't bite back later on ;)