### PR TITLE
Make boolean literals work in the value of object

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -59,6 +59,12 @@ JsonNode *vnode(char *str)
 		return json_mknumber(num);
 	}
 
+	if (strcmp(str, "true") == 0) {
+		return json_mkbool(true);
+	} else if (strcmp(str, "false") == 0) {
+		return json_mkbool(false);
+	}
+
 	if (*str == '{' || *str == '[') {
 		JsonNode *obj = json_decode(str);
 


### PR DESCRIPTION
Hi, thank you for your great work! The jo command must be a promising cli tool for generating a JSON value in terminal!

First thing that I thought it inconvenient is the boolean syntax. This pull request enables me to use boolean literals in more readable syntax than `@0`, `@1`, or `@T`.
```
 $ ./jo foo=true
{"foo":true}
```
Oh, with this change, we cannot specify a string `"true"` for values of object. I want to make the following work but I do not know how to change the code.
```
 $ ./jo foo="true"
{"foo":"true"}
```