### PR TITLE
Change the spacer for pretty print to two spaces (from three spaces)

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -30,7 +30,7 @@
 # define FALSE	(0)
 #endif
 
-#define SPACER		"   "
+#define SPACER		"  "
 #define FLAG_ARRAY	0x01
 #define FLAG_PRETTY	0x02
 #define FLAG_NOBOOL	0x04


### PR DESCRIPTION
The leading spaces used to be three spaces but it's uncommon to use an odd number of leading spaces in programming languages. Two, four, eight or hard tab indentation are commonly used and you can decide which one to use. In my opinion, two spaces are comfortable for me because it does not indents the inner elements too much, readable enough, and what is important, jq pretty-prints with two spaces.

Current behaviour:
```
 $ jo -p foo=jo bar=1 baz=true
{
   "foo": "jo",
   "bar": 1,
   "baz": true
}
 $ jo -pa foo bar baz
[
   "foo",
   "bar",
   "baz"
]
```

With this patch:
```
 $ jo -p foo=jo bar=1 baz=true
{
  "foo": "jo",
  "bar": 1,
  "baz": true
}
 $ jo -pa foo bar baz
[
  "foo",
  "bar",
  "baz"
]
 $ jo -p foo=jo bar=1 baz=true | jq -M . # oh, jo outputs exactly same as jq!
{
  "foo": "jo",
  "bar": 1,
  "baz": true
}
```