### PR TITLE
Add support for using pledge() on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,13 +8,13 @@ AC_PROG_CC
 
 # Checks for header files.
 AC_USE_SYSTEM_EXTENSIONS
-AC_CHECK_HEADERS([stddef.h stdint.h stdlib.h string.h])
+AC_CHECK_HEADERS([stddef.h stdint.h stdlib.h string.h unistd.h])
 
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_FUNC_STRTOD
-AC_CHECK_FUNCS([strchr strrchr strlcpy strlcat snprintf])
+AC_CHECK_FUNCS([strchr strrchr strlcpy strlcat snprintf pledge])
 
 AM_INIT_AUTOMAKE([foreign -Wall])
 AM_SILENT_RULES([yes])

--- a/jo.c
+++ b/jo.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <ctype.h>
+#include <err.h>
 #include "json.h"
 
 /*
@@ -362,6 +363,12 @@ int main(int argc, char **argv)
 	int ttyin = isatty(fileno(stdin)), ttyout = isatty(fileno(stdout));
 	int flags = 0;
 	JsonNode *json, *op;
+
+#if HAVE_PLEDGE
+	if (pledge("stdio", NULL) == -1) {
+		err(1, "pledge");
+	}
+#endif
 
 	progname = (progname = strrchr(*argv, '/')) ? progname + 1 : *argv;
 


### PR DESCRIPTION
This diff adds support for OpenBSD [pledge(2)](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man2/pledge.2). 

First time I tweak some autotools related files so I hope I didn't break anything :D I'm not sure if `unistd.h` should be added to **AC_CHECK_HEADERS** in `configure.ac`, and tests without it seems to run fine, however it might be better to have it to be on the safe side?

Tested on OpenBSD, NetBSD and Mac OS X.