### PR TITLE
mark as only requiring autoconf 2.63

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.64])
+AC_PREREQ([2.63])
 AC_INIT([jo], [1.1], [jpmens@gmail.com])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_SRCDIR([jo.c])


### PR DESCRIPTION
This marks itself as requiring autoconf 2.64, but doesn't actually use any features from 2.64.

2.63 was part of RHEL 6 so it's in a lot of enterprise distros (RHEL, CentOS, Oracle, etc).

I test and with this patch was able to build jo 1.1 on CentOS 6 with no other changes.