### PR TITLE
Add a Dockerfile to this repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine AS builder
+RUN apk -U add automake autoconf build-base make
+COPY . /src
+WORKDIR /src
+RUN autoreconf -i && ./configure && make check && make install
+
+FROM alpine
+COPY --from=builder /usr/local/bin/jo /bin/jo
+ENTRYPOINT ["/bin/jo"]


### PR DESCRIPTION
This commit adds a two-stage Docker build to this repository. The first
step uses an Alpine Linux based image to build the source of jo, and
then this stage is discarded (except for the compiled binary) and a new
Alpine based image is produced containing the jo binary.

The built image can then be executed as:

    [user@host] $ docker run --rm -ti jo a=b
    {"a": "b"}