### PR TITLE
Add snap support for jo

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: jo
+version: "1.2"
+summary: jo
+description: |
+  This is jo, a small utility to create JSON objects or arrays.
+
+confinement: strict
+grade: stable
+
+apps:
+  jo:
+    command: jo
+
+parts:
+  jo:
+    plugin: autotools
+    source-type: git
+    source: https://github.com/jpmens/jo


### PR DESCRIPTION
This commit introduces support the bundling/delivering jo through
the 'snap' mechanism/store - for more details see https://snapcraft.io.

"A snap is a bundle of your app and its dependencies that works without
modification across Linux. Snaps are discoverable and installable from
the Snap store, an app store with an audience of millions." [1]

In case the support/snapcraft.yaml file is accepted it can be published
in the Snap Store [2] which is required for people to easily install it.

Assistance for publishing in the snap store is available if required.

Test Procedure
==============

Build/Snap
----------

$ sudo apt install -y lxd lxd-clients
$ lxc launch ubuntu:16.04 snapcrafting  # create 'snapcrafting' container
$ lxc exec snapcrafting -- su - ubuntu  # execute user shell in container

$ sudo snap install snapcraft --classic # install snapcraft tool/commands
$ sudo apt-get update # update for installing build dependencies packages

$ git clone https://github.com/jpmens/jo
$ cd jo

$ # get this snapcraft.yaml file
$ snapcraft
Pulling jo
...
Building jo
autoreconf -i
...
./configure --prefix=
...
make -j4
...
Snapping 'jo' |
Snapped jo_1.2_amd64.snap

Install
-------

$ sudo snap install jo_1.2_amd64.snap --dangerous # '--dangerous' is required as this isn't from the store.

$ which jo
/snap/bin/jo

Testing
--------

$ jo -p -d. name=Jane point[]=1 point[]=2 geo.lat=10 geo.lon=20
{
   "name": "Jane",
   "point": [
      1,
      2
   ],
   "geo": {
      "lat": 10,
      "lon": 20
   }
}

References:
[1] "Creating a snap" in https://docs.snapcraft.io/creating-a-snap/6799
[2] "Share with your friends" in https://docs.snapcraft.io/c-c-applications/7817