### PR TITLE
Support reading nested data from pipes

### DIFF
--- a/jo.1
+++ b/jo.1
@@ -38,7 +38,8 @@ specified.
 .PP
 When the \f[C]:=\f[] operator is used in a \f[I]word\f[], the name to
 the right of \f[C]:=\f[] is a file containing JSON which is parsed and
-assigned to the key left of the operator.
+assigned to the key left of the operator.  The file may be specified as
+\f[C]-\f[] to read from \f[I]jo\f[]\[aq]s standard input.
 .SH TYPE COERCION
 .PP
 \f[I]jo\f[]\[aq]s type guesses can be overridden on a per\-word basis by

--- a/tests/jo.19.exp
+++ b/tests/jo.19.exp
@@ -1,0 +1,1 @@
+{"foo":["hello world"]}

--- a/tests/jo.19.sh
+++ b/tests/jo.19.sh
@@ -1,0 +1,3 @@
+# read from pipe
+
+echo '["hello world"]' | ${JO:-jo} foo:=-


### PR DESCRIPTION
slurp_file was adapted so that if it cannot determine the size of the
input file, the buffer it reads into is dynamically extended while
reading.

Input files may now be specified as "-" to read from jo's standard
input.

slurp_file's signature was changed so that the name of the file to
read is passed as argument, rather than a file pointer, as the file
pointer was never used after the file was slurped anyway.