### PR TITLE
snap: Add home and removable-media interfaces.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,6 +10,7 @@ grade: stable
 apps:
   jo:
     command: jo
+    plugs: [home, removable-media]
 
 parts:
   jo:


### PR DESCRIPTION
These allow file access to non-hidden files in the user's home
directory, and to /media, /run/media, and /mnt.

The removable-media interface is not connected by default (and hence
files in /media, /run/media, and /mnt will not be accessible), this can
be connected with `snap connect jo:removable-media`