### PR TITLE
Handle invalid JSON when reading from a file.

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -260,7 +260,7 @@ JsonNode *vnode(char *str, int flags)
 		bool binmode = (*str == '%');
 		bool jsonmode = (*str == ':');
 		size_t len = 0;
-		JsonNode *j;
+		JsonNode *j = NULL;
 
 		if ((content = slurp_file(filename, &len, false)) == NULL) {
 			errx(1, "Error reading file %s", filename);
@@ -277,7 +277,10 @@ JsonNode *vnode(char *str, int flags)
 			free(encoded);
 		} else if (jsonmode) {
 			j = json_decode(content);
-		} else {
+		}
+
+		// If it got this far without valid JSON, just consider it a string
+		if (j == NULL) {
 			char *bp = content + strlen(content) - 1;
 
 			if (*bp == '\n') *bp-- = 0;

--- a/tests/jo.22.exp
+++ b/tests/jo.22.exp
@@ -1,0 +1,1 @@
+{"huh":"invalid json"}

--- a/tests/jo.22.sh
+++ b/tests/jo.22.sh
@@ -1,0 +1,7 @@
+# read nested json elements
+
+echo 'invalid json' > $$.1
+
+${JO:-jo} huh=:$$.1
+
+rm -f $$.1


### PR DESCRIPTION
Most likely won't produce the correct result, but avoids crashing and maintains
backward compatibility.