### PR TITLE
Make string type coercion work for objects and arrays

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -295,6 +295,9 @@ JsonNode *vnode(char *str, int flags)
 	}
 
 	if (*str == '{' || *str == '[') {
+		if (type == JSON_STRING) {
+			return json_mkstring(str);
+		}
 		JsonNode *obj = json_decode(str);
 
 		if (obj == NULL) {


### PR DESCRIPTION
I use jo (with curl) to test apis. I once needed a string field  whose content is actually a json object. For example, I needed that:
```sh
$ jo -p -- -s foo=$(jo bar=42)
{
 "foo"="{\"bar\": 42}"
}
```
instead of
```sh
{
   "foo": {
      "bar": 42
   }
}
```

I did not implement type coercion generically because I'm not sure which transformations could make sense. I think is easy to think as empty object/array as falsy/0 but in js:
```js
Number([]) -> 0
Number({}) -> NaN
Boolean([]) -> true
Boolean({}) -> true```

