### PR TITLE
make jo build on systems without the absolute latest pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,19 @@ AC_CHECK_HEADERS([stddef.h stdint.h stdlib.h string.h unistd.h stdbool.h])
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([strchr strrchr strlcpy strlcat snprintf pledge err errx])
 
+# backport PKG_CHECK_VAR from pkgconfig 0.29
+m4_ifndef([PKG_CHECK_VAR], [AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])dnl PKG_CHECK_VAR
+])
+
+
 AM_INIT_AUTOMAKE([foreign -Wall])
 AM_SILENT_RULES([yes])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])


### PR DESCRIPTION
#102 made this tool depend on pkg-config 0.29, which is only in the absolute latest bleeding-edge distros, and which I don't have.

This is just copied from `pkg.m4` in the pkg-config 0.29 source, and wrapped in `m4_ifndef`.

Fixes #105, at least on my systems.