### PR TITLE
Fix coercion flag logic

### DIFF
--- a/tests/jo.17.exp
+++ b/tests/jo.17.exp
@@ -6,6 +6,10 @@
 {"s":"false","n":0,"b":false,"a":false}
 {"s":"","n":0,"b":false,"a":null}
 ["123",14,true,456]
+["-s",2,true]
+["--test","--toast"]
+{"--test":"--toast"}
+[true,"--toast","--test","--toast",6,"--toast"]
 {"s":false,"n":false,"b":false,"a":false}
 {"s":true,"n":true,"b":true,"a":true}
 {"s":"Jan-Piet Mens <jpmens@gmail.com>","n":"Jan-Piet Mens <jpmens@gmail.com>","b":"Jan-Piet Mens <jpmens@gmail.com>","a":"Jan-Piet Mens <jpmens@gmail.com>"}

--- a/tests/jo.17.sh
+++ b/tests/jo.17.sh
@@ -8,6 +8,16 @@ done
 # coerce array items
 ${JO:-jo} -a -- -s 123 -n "This is a test" -b C_Rocks 456
 
+# coercion flag strings should be usable as inputs, when they aren't flags
+${JO:-jo} -a -- -s -s -n -n -b -b
+
+# non-flag strings should be read as normal strings, even if they begin with "-"
+${JO:-jo} -a -- --test --toast
+${JO:-jo} -- --test=--toast
+
+# coercion is one-shot, so all "--toast" strings are normal input
+${JO:-jo} -a -- -b --test --toast -s --test --toast -n --test --toast
+
 ### These should NOT be coerced
 
 # @ booleans


### PR DESCRIPTION
Original code treated all "-"-prefixed inputs as potential flags.

Fixes #127.