### PR TITLE
Fix some gcc warnings

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -465,13 +465,11 @@ int member_to_object(JsonNode *object, int flags, char key_delim, char *kv)
 
 	JsonNode *val;
 	if (p) {
-		if (p) {
-			*p = 0;
-			val = vnode(p+1, flags);
+		*p = 0;
+		val = vnode(p+1, flags);
 
-			if (!resolve_nested(flags, &kv, key_delim, val, &object))
-				json_append_member(object, kv, val);
-		}
+		if (!resolve_nested(flags, &kv, key_delim, val, &object))
+			json_append_member(object, kv, val);
 	} else {
 		if (q) {
 			*q = 0;

--- a/jo.c
+++ b/jo.c
@@ -567,9 +567,9 @@ char* locale_from_utf8(const char *utf8, size_t len)
 # define locale_free(p) free(p)
 #else
 # define utf8_from_locale(p, l) (p)
-# define utf8_free(p)
+# define utf8_free(p) do {} while (0)
 # define locale_from_utf8(p, l) (p)
-# define locale_free(p)
+# define locale_free(p) do {} while (0)
 #endif
 
 char *stringify(JsonNode *json, int flags)

--- a/jo.c
+++ b/jo.c
@@ -374,6 +374,8 @@ bool resolve_nested(int flags, char **keyp, char key_delim, JsonNode *value, Jso
 	JsonNode *op;
 	int found = false;
 
+	(void)flags;
+
 	if (key_delim) {
 		/* First construct nested object */
 		while ((so = strchr(*keyp, key_delim)) != NULL) {

--- a/json.c
+++ b/json.c
@@ -1225,9 +1225,9 @@ void emit_string(SB *out, const char *str)
 #endif
 						b += 6;
 					} else {
-						*b++ = 0xEF;
-						*b++ = 0xBF;
-						*b++ = 0xBD;
+						*b++ = (char)0xEF;
+						*b++ = (char)0xBF;
+						*b++ = (char)0xBD;
 					}
 					s++;
 				} else if (c < 0x1F || (c >= 0x80 && escape_unicode)) {


### PR DESCRIPTION
Fixes some mild warnings of integer overflow, unused argument, empty body for an if statement and a cppcheck (a static analyzer) issue with duplicated if statements, there are additional cppcheck issues, but I'm not sure if they are worth fixing at this time