### PR TITLE
json.c: replace some asserts with errors

### DIFF
--- a/tests/jo.27.exp
+++ b/tests/jo.27.exp
@@ -1,0 +1,6 @@
+{"b":[1,2]}
+jo: JSON_ERR: Cannot add {"a":3} to non-object [1]
+Test 2 should fail
+{"d":{"m":10,"n":20}}
+jo: JSON_ERR: Cannot append 20 to non-array {"m":10}
+Test 4 should fail

--- a/tests/jo.27.sh
+++ b/tests/jo.27.sh
@@ -1,0 +1,6 @@
+# user-friendly errors
+${JO:-jo} b[]=1 b[]=2
+${JO:-jo} b[]=1 b[a]=3 2>&1 || echo "Test 2 should fail"
+
+${JO:-jo} d[m]=10 d[n]=20
+${JO:-jo} d[m]=10 d[]=20 2>&1 || echo "Test 4 should fail"


### PR DESCRIPTION
The asserts replaced are all a direct result of errors in user input,
and for which user-comprehensible error messages can be generated.

Should-not-happen asserts, and those that can't be reported
meaningfully to the users, have been retained.

Closes https://github.com/jpmens/jo/issues/160.