### PR TITLE
Update README with Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,27 +51,34 @@ make check
 make install
 ```
 
-## Homebrew
+## Install
+
+### Homebrew
 
 ```bash
 brew install jo
 ```
 
-## Ubuntu
+### Ubuntu
 
 ```
 apt-get install jo
 ```
 
-## Gentoo
+### Gentoo
 
 ```
 emerge jo
 ```
 
-## Snap
+### Snap
 
 Thanks to [Roger Light](https://twitter.com/ralight/status/1166023769623867398), _jo_ is available as a [snap package](https://snapcraft.io/jo). Use `snap install jo` from a Linux distro that supports snaps.
+
+### Windows
+```cmd
+scoop install jo
+```
 
 ## Others
 


### PR DESCRIPTION
It's now possible to install `jo` using [scoop.sh](https://scoop.sh/) installer. 

NOTE: Please merge this PR after ScoopInstaller/Main/pull/3289