### PR TITLE
docs: add Fedora install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ apt-get install jo
 emerge jo
 ```
 
+### Fedora
+
+```
+dnf install jo
+```
+
 ### Snap
 
 Thanks to [Roger Light](https://twitter.com/ralight/status/1166023769623867398), _jo_ is available as a [snap package](https://snapcraft.io/jo). Use `snap install jo` from a Linux distro that supports snaps.


### PR DESCRIPTION
This just adds a little install instruction to the README for Fedora systems using `dnf`.