### PR TITLE
Fix build from Github instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ make install
 To install from the repository, you will need a C compiler as well as a relatively recent version of _automake_ and _autoconf_.
 
 ```bash
-git clone git://github.com/jpmens/jo.git
+git clone git@github.com:jpmens/jo.git  # or git clone https://github.com/jpmens/jo.git
 cd jo
 autoreconf -i
 ./configure


### PR DESCRIPTION
According to
[Improving Git protocol security on GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github/),
anonymous access using `git://` URLs no longer works.

Use keyed ssh-access or https instead.