### PR TITLE
Add support for building on AIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ As shown in [#175](https://github.com/jpmens/jo/issues/175) when using _git_ on 
 git config --local core.autocrlf false
 ```
 
+### AIX
+
+_jo_ builds and passes all tests on AIX 7.1 using the _autoconf_, _automake_, _gcc_, and _pkg-config_ RPMs from IBM's [AIX Toolbox for Open Source Software](https://www.ibm.com/support/pages/node/883796).  The _xlclang_ compiler from IBM's xlC/C++ suite for AIX will also build _jo_.
+
 ## Others
 
 * [voidlinux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/jo)

--- a/jo.c
+++ b/jo.c
@@ -4,9 +4,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#include <getopt.h>
+#ifndef _AIX
+# include <getopt.h>
+#endif
 #include <ctype.h>
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_AIX)
 # include <err.h>
 #endif
 #include "json.h"
@@ -44,9 +46,12 @@
 
 static JsonNode *pile;		/* pile of nested objects/arrays */
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(_AIX)
 # define err(n, s)	{ fprintf(stderr, s); exit(n); }
 # define errx(n, f, a)	{ fprintf(stderr, f, a); exit(n); }
+#endif
+
+#ifdef _WIN32
 # define fseeko	fseek
 # define ftello	ftell
 #endif

--- a/json.c
+++ b/json.c
@@ -34,9 +34,9 @@
 		exit(EXIT_FAILURE);                     \
 	} while (0)
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(_AIX)
 # define failx(e, n, f, ...)	if (!(e)) {	\
-		fprintf(stderr, "JSON_ERR: " f, __VA_ARGS__);	\
+		fprintf(stderr, "jo: JSON_ERR: " f "\n", __VA_ARGS__);	\
 		exit(n);	\
 	}
 #else


### PR DESCRIPTION
AIX does not by default include the err() family of functions or GNU
getopt.  Piggyback on the Windows workarounds for these differences,
and modify failx() in json.c to emulate errx() more accurately.