### PR TITLE
Add option -o outfile

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,8 @@ jo1 = custom_target('jo.1',
                     command: [pandoc_commands, '@OUTPUT@', '@INPUT@']).full_path()
 run_command(pandoc_commands,
             join_paths(meson.current_build_dir(), 'jo.1'),
-            join_paths(meson.current_source_dir(), 'jo.pandoc'))
+            join_paths(meson.current_source_dir(), 'jo.pandoc'),
+            check: false)
 custom_target('jo.md',
               output: 'jo.md',
               input: 'jo.pandoc',


### PR DESCRIPTION
This PR is to add a new option `-o outfile`.

While adding it, I found that meson is generating a warning about run_command.  This PR includes a small fix for that as well.