### PR TITLE
Fix warnings on Windows and reimplement err and errx as functions

### DIFF
--- a/jo.c
+++ b/jo.c
@@ -51,7 +51,7 @@ static JsonNode *pile;		/* pile of nested objects/arrays */
 # define errx(n, f, a)	{ fprintf(stderr, f, a); exit(n); }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(fseeko)
 # define fseeko	fseek
 # define ftello	ftell
 #endif

--- a/jo.c
+++ b/jo.c
@@ -167,7 +167,7 @@ char *slurp_file(const char* filename, size_t *out_len, bool fold_newlines)
 	}
 
 	buf = slurp(fp, buffer_len, EOF, out_len, fold_newlines);
-	if (*out_len < 0) {
+	if (*out_len == (size_t)-1) {
 		errx(1, "File %s is too large to be read into memory", filename);
 	}
 	if (!use_stdin) fclose(fp);
@@ -179,7 +179,7 @@ char *slurp_line(FILE *fp, size_t *out_len)
 	char *buf;
 
 	buf = slurp(fp, SLURP_BLOCK_SIZE, '\n', out_len, false);
-	if (*out_len < 0) {
+	if (*out_len == (size_t)-1) {
 		errx(1, "Line too large to be read into memory");
 	}
 	return buf;
@@ -545,7 +545,7 @@ char* utf8_from_locale(const char *str, size_t len)
 	if (len == 0) {
 		return strdup("");
 	}
-	if (len == -1) {
+	if (len == (size_t)-1) {
 		len = strlen(str);
 	}
 	wcssize = MultiByteToWideChar(GetACP(), 0, str, len,  NULL, 0);
@@ -578,7 +578,7 @@ char* locale_from_utf8(const char *utf8, size_t len)
 	if (len == 0) {
 		return strdup("");
 	}
-	if (len == -1) {
+	if (len == (size_t)-1) {
 		len = strlen(utf8);
 	}
 	wcssize = MultiByteToWideChar(CP_UTF8, 0, utf8, len,  NULL, 0);

--- a/jo.c
+++ b/jo.c
@@ -47,8 +47,32 @@
 static JsonNode *pile;		/* pile of nested objects/arrays */
 
 #if defined(_WIN32) || defined(_AIX)
-# define err(n, s)	{ fprintf(stderr, s); exit(n); }
-# define errx(n, f, a)	{ fprintf(stderr, f, a); exit(n); }
+#include <errno.h>
+#include <stdarg.h>
+static inline void err(int eval, const char *fmt, ...) {
+	int errnum = errno;
+
+	va_list ap;
+	va_start(ap, fmt);
+
+	fprintf(stderr, "jo: ");
+	vfprintf(stderr, fmt, ap);
+	fprintf(stderr, ": %s\n", strerror(errnum));
+
+	va_end(ap);
+	exit(eval);
+}
+static inline void errx(int eval, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+
+	fprintf(stderr, "jo: ");
+	vfprintf(stderr, fmt, ap);
+	fprintf(stderr, "\n");
+
+	va_end(ap);
+	exit(eval);
+}
 #endif
 
 #if defined(_WIN32) && !defined(fseeko)


### PR DESCRIPTION
See: https://github.com/jpmens/jo/pull/192

Fixes some warnings produced by mingw-w64 gcc regarding signed<->unsigned comparison and comparing against less than 0 for unsigned numbers, along with redefined macros.

Also reimplements the macros err and errx as functions based on the man page description, minus a few sections due to those conditions not being met in any of the calls.

Confirmed this to work on both linux with `gcc (GCC) 12.2.0` and `x86_64-w64-mingw32-gcc (GCC) 12.2.0` from archlinux and from `cc.exe (Rev4, Built by MSYS2 project) 12.2.0` from ucrt64 from MSYS2.

To reproduce on a linux machine with mingw-w64 gcc and meson installed
```bash
cat > x86_64-w64-mingw32.txt <<'EOF'
[binaries]
c = 'x86_64-w64-mingw32-gcc'
cpp = 'x86_64-w64-mingw32-g++'
ar = 'x86_64-w64-mingw32-ar'
strip = 'x86_64-w64-mingw32-strip'
exe_wrapper = 'wine64'

[host_machine]
system = 'windows'
cpu_family = 'x86_64'
cpu = 'x86_64'
endian = 'little'
EOF
meson setup --cross-file x86_64-w64-mingw32.txt build-mingw
meson compile -C build-mingw
```