### PR TITLE
Update Arch Linux package URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ _jo_ builds and passes all tests on AIX 7.1 using the _autoconf_, _automake_, _g
 ## Others
 
 * [voidlinux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/jo)
-* [ArchLinux](https://archlinux.org/packages/community/x86_64/jo/)
+* [ArchLinux](https://archlinux.org/packages/extra/x86_64/jo/)
 * [OpenBSD](http://openports.se/textproc/jo)
 * [FreeBSD](https://www.freshports.org/textproc/jo)
 * [Guix](https://guix.gnu.org/packages/jo-1.4/)


### PR DESCRIPTION
The old URL returns 404 now.