### PR TITLE
Update zsh completion with new options

### DIFF
--- a/jo.zsh
+++ b/jo.zsh
@@ -4,16 +4,20 @@
 # Store this file in a directory listed in $fpath for it to be picked up
 # by compinit. It needs to be named with an initial underscore, e.g. _jo
 
-local curcontext="$curcontext"
+local curcontext="$curcontext" sep
 local -i aopt nm=$compstate[nmatches]
-local -a expl line state state_descr
+local -a expl line state state_descr disp
 local -A opt_args
 
 _arguments -C -s -A "-*" \
   '(-h)-p[pretty-print JSON on output]' \
   '(-d -h)-a[create an array of words]' \
   '(-v -V -h)-B[disable interpretation of true/false/null strings]' \
+  '(-v -V -h)-D[deduplicate object keys]' \
+  '(-v -V -h)-f+[first load file then modify it]:file:_files -g "*.json(-.)"' \
   "(-v -V -h)-e[if stdin is empty don't wait for input - quit]" \
+  "(-v -V -h)-n[don't add keys with empty values]" \
+  '(-v -V -h)-o+[specify output file]:file:_files' \
   '(- *)-v[show version information]' \
   '(-a -B -e -h -v *)-V[show version in JSON]' \
   '(-a -h -v -V)-d+[key will be object path separated by given delimiter]:key delimiter' \
@@ -48,12 +52,15 @@ if [[ -n $state ]]; then
     compadd -M 'm:{a-zA-Z}={A-Za-z} m:{10}={TF}' "$expl[@]" True False
   else
     if compset -P '[^-]*'; then
-      _describe -t suffixes suffix '(
-        @:boolean\ element
-        \=:value
-        \\:=:substitute\ JSON\ file
-        \[\]:array\ element
-      )' -S ''
+      zstyle -s ":completion:${curcontext}:operators" list-separator sep || sep=--
+      disp=(
+        "@  $sep boolean element"
+        "=  $sep value"
+        ":= $sep substitute JSON file"
+        "[] $sep array element"
+      )
+      _description operators expl 'operator'
+      compadd -S '' "$expl[@]" -ld disp '@' '=' ':=' '[]='
     fi
     _message -e keys key
   fi


### PR DESCRIPTION
This adds the new -D, -n, -f and -o options to the zsh completion and changes the completion for the assignment operators to better handle different forms of quoting of the current word on the command-line.