### PR TITLE
Update GPL-2.0-or-later license notices

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -12,8 +12,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
  */
 
 #--------------------------------------------------------------------

--- a/debian/copyright
+++ b/debian/copyright
@@ -16,5 +16,5 @@ License: GPLv2
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ along with this program; if not, see
+ <https://www.gnu.org/licenses/>.

--- a/jo.c
+++ b/jo.c
@@ -28,8 +28,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
  */
 
 #define SPACER		"   "


### PR DESCRIPTION
The FSF is now remote-only, and no longer has a physical address. Based on https://www.gnu.org/licenses/old-licenses/gpl-2.0.html#SEC4.